### PR TITLE
fix(typo): fix typo in BaseEvent model

### DIFF
--- a/py_ocsf_models/events/base_event.py
+++ b/py_ocsf_models/events/base_event.py
@@ -84,4 +84,4 @@ class BaseEvent(BaseModel):
     status_code: Optional[str]
     status_detail: Optional[str]
     status_id: Optional[StatusID]
-    unmapped_data: object
+    unmapped_data: Optional[object]

--- a/py_ocsf_models/events/base_event.py
+++ b/py_ocsf_models/events/base_event.py
@@ -70,7 +70,7 @@ class BaseEvent(BaseModel):
     - Status Code (status_code) [Optional]: The event status code, as reported by the event source. For example, in a Windows Failed Authentication event, this would be the value of 'Failure Code', e.g. 0x18.
     - Status Details (status_detail) [Optional]: The status details contains additional information about the event/finding outcome.
     - Status ID (status_id) [Optional]: The normalized status identifier of the Finding, set by the consumer.
-    - Unmapped Data (unmapped_data) [Optional]: The attributes that are not mapped to the event schema. The names and values of those attributes are specific to the event source.
+    - Unmapped Data (unmapped) [Optional]: The attributes that are not mapped to the event schema. The names and values of those attributes are specific to the event source.
     """
 
     enrichments: Optional[list[Enrichment]]
@@ -84,4 +84,4 @@ class BaseEvent(BaseModel):
     status_code: Optional[str]
     status_detail: Optional[str]
     status_id: Optional[StatusID]
-    unmapped_data: Optional[object]
+    unmapped: Optional[object]


### PR DESCRIPTION
### Context

The attribute `unmapped_data` breaks the consistency from https://schema.ocsf.io/1.1.0/classes/detection_finding?extensions= where it is said that UnmappedData should have an attribute named `unmapped`


### Description

This pr changes the attribute unmapped_data to unmapped in BaseEvent class


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
