### PR TITLE
fix: ignore pip vuln

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Safety
         run: |
-          poetry run safety check
+          poetry run safety check --ignore 67599
 
       - name: Vulture
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
       - id: safety
         name: safety
         description: "Safety is a tool that checks your installed dependencies for known security vulnerabilities"
-        entry: bash -c 'safety check'
+        entry: bash -c 'safety check --ignore 67599'
         language: system
 
       - id: vulture


### PR DESCRIPTION
### Motivation

Ignore Safety vulnerability https://data.safetycli.com/v/67599/97c/ since it does not apply as we do not use -extra-index-url flag with pip.

### Description
Add `--ignore 67599` flag to safety check.
