### PR TITLE
chore(security): pin SHA in actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install poetry
         run: |
@@ -24,7 +24,7 @@ jobs:
           pipx install poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
@@ -43,7 +43,7 @@ jobs:
           poetry run flake8 . --ignore=E501
 
       - name: Lint with ruff
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@9828f49eb4cadf267b40eaa330295c412c68c1f9 # v3.2.2
 
       - name: Checking format with black
         run: |
@@ -74,7 +74,7 @@ jobs:
           poetry run pytest -n auto --cov=./py_ocsf_models --cov-report=xml tests
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5.4.0
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: prowler-cloud/py-ocsf-models


### PR DESCRIPTION
### Context

Due to a recent security incident with `tj-actions/changed-files` where all of their tags where infected with malicious code we decided to pin all actions to the full-length commit SHA. Dependabot and Renovatebot are able of updating the code when using the full-length SHA.

### Description

Pin actions to the Full-Length Commit SHA.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
