### PR TITLE
fix(security): workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,9 @@
 name: PR - Lint and Test
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/prowler-cloud/py-ocsf-models/security/code-scanning/3](https://github.com/prowler-cloud/py-ocsf-models/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uploads coverage reports to Codecov. Therefore, the `contents: read` and `pull-requests: write` permissions are sufficient. These permissions will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
