### PR TITLE
feat: AffectedSoftwarePackage object

### DIFF
--- a/py_ocsf_models/objects/affected_software_package.py
+++ b/py_ocsf_models/objects/affected_software_package.py
@@ -1,0 +1,64 @@
+from enum import IntEnum
+from typing import Optional
+
+from pydantic.v1 import BaseModel
+
+from py_ocsf_models.objects.fingerprint import FingerPrint
+from py_ocsf_models.objects.remediation import Remediation
+
+
+class SoftwarePackageTypeID(IntEnum):
+    Unknown = 0
+    Application = 1
+    Operating_System = 2
+    Other = 99
+
+
+class AffectedSoftwarePackage(BaseModel):
+    """
+    The Affected Package object describes details about a software package identified as affected by a vulnerability/vulnerabilities.
+
+    Attributes:
+    - Architecture (architecture) [Recommended]: Architecture is a shorthand name describing the type of computer hardware the packaged software is meant to run on.
+    - The product CPE identifier (cpe_name) [Optional]: The Common Platform Enumeration (CPE) name as described by (NIST) For example: cpe:/a:apple:safari:16.2.
+    - Epoch (epoch) [Optional]: Integer The software package epoch. Epoch is a way to define weighted dependencies based on version numbers.
+    - Fixed In Version (fixed_in_version) [Optional]: The software package version in which a reported vulnerability was patched/fixed.
+    - Hash (hash) [Optional]: Fingerprint Cryptographic hash to identify the binary instance of a software component. This can include any component such file, package, or library.
+    - Software License (license) [Optional]: The software license applied to this package.
+    - Software License URL (license_url) [Optional]: The URL pointing to the license applied on package or software. This is typically a LICENSE.md file within a repository.
+    - Name (name) [Required]: The software package name.
+    - Package Manager (package_manager) [Optional]: The software packager manager utilized to manage a package on a system, e.g. npm, yum, dpkg etc.
+    - Package Manager URL (package_manager_url) [Optional]: The URL of the package or library at the package manager, or the specific URL or URI of an internal package manager link such as AWS CodeArtifact or Artifactory.
+    - Path (path) [Optional]: The installation path of the affected package.
+    - Package URL (purl) [Optional]: A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programming languages, package managers, packaging conventions, tools, APIs and databases.
+    - Software Release Details (release) [Optional]: Release is the number of times a version of the software has been packaged.
+    - Remediation Guidance (remediation) [Optional]: Remediation Describes the recommended remediation steps to address identified issue(s).
+    - Source URL (src_url) [Optional]: The link to the specific library or package such as within GitHub, this is different from the link to the package manager where the library or package is hosted.
+    - Type (type) [Optional]: The type of software package, normalized to the caption of the type_id value. In the case of 'Other', it is defined by the source. This is the string sibling of enum attribute type_id.
+    - Type ID (type_id) [Recommended]: Integer The type of software package.
+    - Package UID (uid) [Optional]: A unique identifier for the package or library reported by the source tool. E.g., the libId within the sbom field of an OX Security Issue or the SPDX components.*.bom-ref.
+    - Vendor Name (vendor_name) [Optional]: The name of the vendor who published the software package.
+    - Version (version) [Required]: The software package version.
+
+    """
+
+    architecture: Optional[str]
+    cpe_name: Optional[str]
+    epoch: Optional[int]
+    fixed_in_version: Optional[str]
+    hash: Optional[FingerPrint]
+    license: Optional[str]
+    license_url: Optional[str]
+    name: Optional[str]
+    package_manager: Optional[str]
+    package_manager_url: Optional[str]
+    path: Optional[str]
+    purl: Optional[str]
+    release: Optional[str]
+    remediation: Optional[Remediation]
+    src_url: Optional[str]
+    type: Optional[str]
+    type_id: Optional[SoftwarePackageTypeID]
+    uid: Optional[str]
+    vendor_name: Optional[str]
+    version: str

--- a/py_ocsf_models/objects/vulnerability_details.py
+++ b/py_ocsf_models/objects/vulnerability_details.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from pydantic.v1 import BaseModel
 
+from py_ocsf_models.objects.affected_software_package import AffectedSoftwarePackage
 from py_ocsf_models.objects.cve import CVE
 from py_ocsf_models.objects.cwe import CWE
 from py_ocsf_models.objects.remediation import Remediation
@@ -38,7 +39,7 @@ class VulnerabilityDetails(BaseModel):
     # TODO
     # advisory: Optional[Advisory]
     # affected_code: Optional[List[AffectedCode]]
-    # affected_packages: Optional[List[AffectedSoftwarePackage]]
+    affected_packages: Optional[List[AffectedSoftwarePackage]]
     cve: Optional[CVE]
     cwe: Optional[CWE]
     desc: Optional[str]

--- a/tests/application_security_posture_finding_test.py
+++ b/tests/application_security_posture_finding_test.py
@@ -11,10 +11,15 @@ from py_ocsf_models.events.findings.application_security_posture_finding import 
 from py_ocsf_models.events.findings.category_uid import CategoryUID
 from py_ocsf_models.events.findings.class_uid import ClassUID
 from py_ocsf_models.events.findings.severity_id import SeverityID
+from py_ocsf_models.objects.affected_software_package import (
+    AffectedSoftwarePackage,
+    SoftwarePackageTypeID,
+)
 from py_ocsf_models.objects.cve import CVE
 from py_ocsf_models.objects.cvss import CVSSScore
 from py_ocsf_models.objects.epss import EPSS
 from py_ocsf_models.objects.finding_info import FindingInformation
+from py_ocsf_models.objects.fingerprint import AlgorithmID, FingerPrint
 from py_ocsf_models.objects.metadata import Metadata
 from py_ocsf_models.objects.metric import Metric
 from py_ocsf_models.objects.product import Feature, Product
@@ -83,6 +88,34 @@ class TestApplicationSecurityPostureFinding:
                     ),
                     severity=SeverityID.Critical.name,
                     title="vuln-log4shell-001",
+                    affected_packages=[
+                        AffectedSoftwarePackage(
+                            architecture="Architecture",
+                            cpe_name="CPE Name",
+                            epoch=1,
+                            fixed_in_version="1.2.3",
+                            hash=FingerPrint(
+                                algorithm_id=1,
+                                algorithm="MD5",
+                                value="d73b04b0e696b0945283defa3eee4538",
+                            ),
+                            license="GPL v3.0",
+                            license_url="https://www.gnu.org/licenses/gpl-3.0.en.html",
+                            name="Package Name",
+                            package_manager="npm",
+                            package_manager_url="https://something/npm/Package Name",
+                            path="/path/to/install/",
+                            purl="PURL",
+                            release="rc1",
+                            remediation=Remediation(desc="remediation"),
+                            src_url="https://example.com/sources",
+                            type="Application",
+                            type_id=1,
+                            uid="Package Name-1.2.2-rc1",
+                            vendor_name="Vendor Name",
+                            version="1.2.3",
+                        ),
+                    ],
                 )
             ],
             resources=[
@@ -139,6 +172,45 @@ class TestApplicationSecurityPostureFinding:
         assert vulnerability.severity == SeverityID.Critical.name
         assert vulnerability.title == "vuln-log4shell-001"
         assert vulnerability.remediation
+        assert vulnerability.affected_packages[0].architecture == "Architecture"
+        assert vulnerability.affected_packages[0].cpe_name == "CPE Name"
+        assert vulnerability.affected_packages[0].epoch == 1
+        assert vulnerability.affected_packages[0].fixed_in_version == "1.2.3"
+        assert vulnerability.affected_packages[0].hash.algorithm_id == AlgorithmID.MD5
+        assert vulnerability.affected_packages[0].hash.algorithm == AlgorithmID.MD5.name
+        assert (
+            vulnerability.affected_packages[0].hash.value
+            == "d73b04b0e696b0945283defa3eee4538"
+        )
+        assert vulnerability.affected_packages[0].license == "GPL v3.0"
+        assert (
+            vulnerability.affected_packages[0].license_url
+            == "https://www.gnu.org/licenses/gpl-3.0.en.html"
+        )
+        assert vulnerability.affected_packages[0].name == "Package Name"
+        assert vulnerability.affected_packages[0].package_manager == "npm"
+        assert (
+            vulnerability.affected_packages[0].package_manager_url
+            == "https://something/npm/Package Name"
+        )
+        assert vulnerability.affected_packages[0].path == "/path/to/install/"
+        assert vulnerability.affected_packages[0].purl == "PURL"
+        assert vulnerability.affected_packages[0].release == "rc1"
+        assert vulnerability.affected_packages[0].remediation.desc == "remediation"
+        assert (
+            vulnerability.affected_packages[0].src_url == "https://example.com/sources"
+        )
+        assert (
+            vulnerability.affected_packages[0].type
+            == SoftwarePackageTypeID.Application.name
+        )
+        assert (
+            vulnerability.affected_packages[0].type_id
+            == SoftwarePackageTypeID.Application
+        )
+        assert vulnerability.affected_packages[0].uid == "Package Name-1.2.2-rc1"
+        assert vulnerability.affected_packages[0].vendor_name == "Vendor Name"
+        assert vulnerability.affected_packages[0].version == "1.2.3"
 
         # Finding Info assertions
         assert (


### PR DESCRIPTION
### Context

This PR adds support for Affected Software Package in the Vulnerability Details class, currently missing. The schema matches OCSF 1.5.0.

### Description

* Add the AffectedSoftwarePackage object in a new file: py_ocsf_models/objects/affected_software_package.py
* uncomment the affected_packages in VulnerabilityDetails
* Update the tests/application_security_posture_finding_test.py accordingly
* pre-commit and pytest passes successfully

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
