### PR TITLE
fix: AffectSoftwarePackage name is required

### DIFF
--- a/py_ocsf_models/objects/affected_software_package.py
+++ b/py_ocsf_models/objects/affected_software_package.py
@@ -49,7 +49,7 @@ class AffectedSoftwarePackage(BaseModel):
     hash: Optional[FingerPrint]
     license: Optional[str]
     license_url: Optional[str]
-    name: Optional[str]
+    name: str
     package_manager: Optional[str]
     package_manager_url: Optional[str]
     path: Optional[str]


### PR DESCRIPTION
According to the official schema, the AffectedSoftwarePackage name is mandatory:
https://schema.ocsf.io/1.5.0/objects/affected_package

### Context

Currently, AffectedSoftwarePackage.name is optional. However, according to the official schema, it's supposed to be required : https://schema.ocsf.io/1.5.0/objects/affected_package.



### Description

Quick bugfix: this does not seem to break any pytest or any pre-commit processes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
