### PR TITLE
chore(deps): relax cryptography upper bound to <50

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2053,6 +2053,8 @@ files = [
     {file = "ruamel.yaml.clib-0.2.14-cp39-cp39-win32.whl", hash = "sha256:6d5472f63a31b042aadf5ed28dd3ef0523da49ac17f0463e10fda9c4a2773352"},
     {file = "ruamel.yaml.clib-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:8dd3c2cc49caa7a8d64b67146462aed6723a0495e44bf0aa0a2e94beaa8432f6"},
     {file = "ruamel.yaml.clib-0.2.14.tar.gz", hash = "sha256:803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e"},
+    {file = "ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539"},
+    {file = "ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008"},
 ]
 
 [[package]]
@@ -2359,4 +2361,4 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "90d9d094995415e0e9c2592999a51dfa23bce8dc629b105b8d0abdd15eee877c"
+content-hash = "5f0ad002234d4dbb2fd0fa8e97c6d9a716e8b2eae9126b24f885195db54dabb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-  "cryptography (>=44.0.3,<47)",
+  "cryptography (>=44.0.3,<50)",
   "email-validator==2.2.0",
   "pydantic (>=2.12.0,<3.0.0)"
 ]


### PR DESCRIPTION
### Context

Implements the cap lift agreed in #300: `cryptography (>=44.0.3,<47)` → `(>=44.0.3,<50)`. The `<47` ceiling excludes the GHSA-537c-gmf6-5ccf fix (cryptography 48.0.1; latest 49.0.0) and forces a resolver conflict for consumers that also need `cryptography>=47`. `cryptography` isn't imported under `py_ocsf_models/`, so the ceiling has no compatibility basis — full rationale in #300.

### Description

Keep the floor, raise the ceiling: `cryptography (>=44.0.3,<50)` — admits 47/48/49, retains a next-major guard. `poetry.lock` regenerated with Poetry 2.1.1 (matching the existing lock); `poetry check --lock` stays green and the resolved `cryptography` is unchanged at 46.0.7, so this only lifts the ceiling. No dependencies added.

Closes #300.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
